### PR TITLE
Update denikn.cz-audio-speed.user.js

### DIFF
--- a/denikn.cz-audio-speed.user.js
+++ b/denikn.cz-audio-speed.user.js
@@ -1,56 +1,80 @@
 // ==UserScript==
-// @name       Change Audio Playback Speed @denikn.cz
+// @name       Change Audio Playback Speed @denikn.cz (n3_audio)
 // @namespace  https://github.com/kofaysi/denikn-userscripts/blob/main/denikn.cz-audio-speed.user.js
-// @version    1.6
-// @description  Monitors and sets the playback speed of the audio based on the last saved value in localStorage, defaulting to 1.5, and saves any changes during the session
+// @version    2.0
+// @description  Persist and apply audio playback speed using the new n3_audio select
 // @match      https://denikn.cz/*
-// @author     https://github.com/kofaysi
 // @grant      none
 // ==/UserScript==
 
-(function() {
-    'use strict';
+(function () {
+  'use strict';
 
-    // Function to set playback speed based on localStorage value
-    function setPlaybackSpeed(savedSpeed) {
-        var radioButtons = document.querySelectorAll('input[name="mep_0_speed"]');
-        for (var i = 0; i < radioButtons.length; i++) {
-            if (radioButtons[i].value === savedSpeed) {
-                radioButtons[i].click();
-                break;
-            }
-        }
-    }
+  const LS_KEY = 'audioPlaybackSpeed';
+  const DEFAULT_SPEED = '1.75';
 
-    // Function to monitor and save any changes in playback speed
-    function monitorSpeedChange() {
-        var radioButtons = document.querySelectorAll('input[name="mep_0_speed"]');
-        for (var i = 0; i < radioButtons.length; i++) {
-            radioButtons[i].addEventListener('change', function() {
-                if (this.checked) {
-                    var newSpeed = this.value;
-                    localStorage.setItem('audioPlaybackSpeed', newSpeed); // Save the new speed
-                }
-            });
-        }
-    }
+  const getAudio = () => document.querySelector('#n3_audio_html5, #n3_audio audio');
+  const getSpeedSelect = () => document.querySelector('.n3_audio_speed');
 
-    // Get the saved speed from localStorage, default to 1.5 if not set
-    var savedSpeed = localStorage.getItem('audioPlaybackSpeed') || "1.75";
+  function applySpeedToUI(val) {
+    const sel = getSpeedSelect();
+    if (!sel) return false;
+    if (![...sel.options].some(o => o.value === val)) return false;
+    sel.value = val;
+    // Fire change to let site logic update UI/ARIA
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+  }
 
-    // Apply the saved speed on page load
-    setPlaybackSpeed(savedSpeed);
+  function applySpeedToAudio(val) {
+    const a = getAudio();
+    if (!a) return false;
+    const num = parseFloat(val);
+    if (!isFinite(num) || num <= 0) return false;
+    a.playbackRate = num;
+    return true;
+  }
 
-    // Start monitoring for any changes to playback speed
-    monitorSpeedChange();
+  function loadSaved() {
+    return localStorage.getItem(LS_KEY) || DEFAULT_SPEED;
+  }
 
-    // Optional: Regularly check and update playback speed (in case the speed is changed by other means)
-    setInterval(function() {
-        var currentSpeed = document.querySelector('input[name="mep_0_speed"]:checked').value;
-        var savedSpeed = localStorage.getItem('audioPlaybackSpeed') || "1.75";
-        if (currentSpeed !== savedSpeed) {
-            localStorage.setItem('audioPlaybackSpeed', currentSpeed); // Update localStorage if speed has changed
-        }
-    }, 1000); // Check every second
+  function save(val) {
+    localStorage.setItem(LS_KEY, String(val));
+  }
 
+  function initOnce() {
+    const sel = getSpeedSelect();
+    const a = getAudio();
+    if (!sel || !a) return false;
+
+    // 1) Set from saved
+    const saved = loadSaved();
+    applySpeedToUI(saved) || (sel && (sel.value = saved));
+    applySpeedToAudio(saved);
+
+    // 2) When user changes select -> save + apply to audio
+    sel.addEventListener('change', () => {
+      const v = sel.value || DEFAULT_SPEED;
+      save(v);
+      applySpeedToAudio(v);
+    });
+
+    // 3) When site changes audio rate -> reflect to UI + save
+    a.addEventListener('ratechange', () => {
+      const v = String(a.playbackRate);
+      applySpeedToUI(v);
+      save(v);
+    });
+
+    return true;
+  }
+
+  // Try now, then watch for late hydration
+  const ready = () => document.readyState === 'complete' || document.readyState === 'interactive';
+  if (ready()) setTimeout(initOnce, 0);
+  else window.addEventListener('DOMContentLoaded', initOnce);
+
+  new MutationObserver(() => initOnce())
+    .observe(document.documentElement, { childList: true, subtree: true });
 })();


### PR DESCRIPTION
Adapt playback speed userscript to new n3_audio player

- replace old radio button speed controls with <select.n3_audio_speed>
- apply saved speed directly to <audio> element via playbackRate
- persist changes in localStorage under 'audioPlaybackSpeed'
- add MutationObserver for late-loaded controls